### PR TITLE
Increasing max length of copyright text

### DIFF
--- a/src/Plugin/Block/AluminumCopyrightBlock.php
+++ b/src/Plugin/Block/AluminumCopyrightBlock.php
@@ -21,6 +21,7 @@ class AluminumCopyrightBlock extends AluminumBlockBase {
                 '#title' => $this->t('Copyright text'),
                 '#description' => $this->t('The text to display. You may use tokens such as [site:name] and [date:custom:Y].'),
                 '#default_value' => 'Copyright [date:custom:Y] [site:name]. All rights reserved.',
+                '#maxlength' => 256,
             ],
         ];
     }


### PR DESCRIPTION
Added a #maxlength key to the field definition to allow for 256 characters in there, to make room for links and other additional text.